### PR TITLE
fix: harden real regression checks

### DIFF
--- a/scripts/claude-real-regression.mjs
+++ b/scripts/claude-real-regression.mjs
@@ -5,8 +5,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 function fail(message) {
-  console.error(`FAIL ${message}`);
-  process.exit(1);
+  throw new Error(String(message || 'unknown failure'));
 }
 
 function ok(message) {
@@ -17,22 +16,7 @@ function quoteForPowerShell(value) {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
-function spawnClaude(args) {
-  if (process.platform === 'win32') {
-    const appData = process.env.APPDATA || '';
-    const claudePs1 = appData ? join(appData, 'npm', 'claude.ps1') : '';
-    if (!claudePs1 || !existsSync(claudePs1)) {
-      return { status: 1, stdout: '', stderr: 'claude.ps1 not found', error: null };
-    }
-
-    const command = `& ${quoteForPowerShell(claudePs1)} ${args.map(quoteForPowerShell).join(' ')}`;
-    return spawnSync('pwsh.exe', ['-NoLogo', '-NoProfile', '-Command', command], {
-      encoding: 'utf8',
-      maxBuffer: 10 * 1024 * 1024,
-      shell: false,
-    });
-  }
-
+function spawnClaudeDirect(args) {
   return spawnSync('claude', args, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
@@ -40,33 +24,113 @@ function spawnClaude(args) {
   });
 }
 
-function ensureClaudeCli() {
-  const result = spawnClaude(['plugins', '--help']);
-  if (result.error || result.status !== 0) {
-    fail('claude CLI is required for real-session regression');
+function spawnClaude(args) {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || '';
+    const claudePs1 = appData ? join(appData, 'npm', 'claude.ps1') : '';
+
+    if (claudePs1 && existsSync(claudePs1)) {
+      const command = `& ${quoteForPowerShell(claudePs1)} ${args.map(quoteForPowerShell).join(' ')}`;
+      return spawnSync('pwsh.exe', ['-NoLogo', '-NoProfile', '-Command', command], {
+        encoding: 'utf8',
+        maxBuffer: 10 * 1024 * 1024,
+        shell: false,
+      });
+    }
   }
+
+  return spawnClaudeDirect(args);
+}
+
+function pluginCommand() {
+  const singular = spawnClaude(['plugin', '--help']);
+  if (!singular.error && singular.status === 0) {
+    return 'plugin';
+  }
+
+  const plural = spawnClaude(['plugins', '--help']);
+  if (!plural.error && plural.status === 0) {
+    return 'plugins';
+  }
+
+  fail('claude CLI is required for real-session regression');
+}
+
+let cachedPluginCommand = '';
+
+function ensureClaudeCli() {
+  if (!cachedPluginCommand) {
+    cachedPluginCommand = pluginCommand();
+  }
+
+  return cachedPluginCommand;
+}
+
+function extractPluginBlock(text, pluginName) {
+  const lines = String(text || '').split(/\r?\n/);
+  const index = lines.findIndex((line) => line.includes(pluginName));
+  if (index < 0) {
+    return '';
+  }
+
+  const block = [lines[index]];
+  for (let i = index + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) {
+      break;
+    }
+
+    if (line.includes('@') && !line.includes(pluginName)) {
+      break;
+    }
+
+    if (/^\S/.test(line)) {
+      break;
+    }
+
+    block.push(line);
+  }
+
+  return block.join('\n');
 }
 
 function ensureHello2ccEnabled() {
-  const result = spawnClaude(['plugins', 'list']);
+  const cliPluginCommand = ensureClaudeCli();
+  const result = spawnClaude([cliPluginCommand, 'list']);
   if (result.error || result.status !== 0) {
     fail('unable to inspect installed Claude Code plugins');
   }
 
   const text = String(result.stdout || '');
-  const blockMatch = text.match(/❯\s+hello2cc@hello2cc-local[\s\S]*?(?=\n\s*❯|\s*$)/);
-  const pluginBlock = blockMatch?.[0] || '';
+  const pluginBlock = extractPluginBlock(text, 'hello2cc@hello2cc-local');
 
   if (!pluginBlock) {
     fail('hello2cc@hello2cc-local is not installed in the current Claude Code environment');
   }
 
-  if (/Status:\s*✘\s*disabled/i.test(pluginBlock)) {
-    const enableResult = spawnClaude(['plugins', 'enable', 'hello2cc@hello2cc-local']);
+  const scopeMatch = pluginBlock.match(/Scope:\s*(user|project|local)/i);
+  const scope = String(scopeMatch?.[1] || '').toLowerCase();
+  const scopedArgs = scope ? ['--scope', scope] : [];
+  const wasDisabled = /Status:\s*✘\s*disabled/i.test(pluginBlock);
+  if (wasDisabled) {
+    const enableResult = spawnClaude([cliPluginCommand, 'enable', ...scopedArgs, 'hello2cc@hello2cc-local']);
     if (enableResult.error || enableResult.status !== 0) {
       fail('hello2cc is installed but disabled, and automatic enable failed');
     }
   }
+
+  return {
+    restore() {
+      if (!wasDisabled) {
+        return;
+      }
+
+      const disableResult = spawnClaude([cliPluginCommand, 'disable', ...scopedArgs, 'hello2cc@hello2cc-local']);
+      if (disableResult.error || disableResult.status !== 0) {
+        fail('hello2cc was initially disabled, but restoring the disabled state failed after real-session regression');
+      }
+    },
+  };
 }
 
 function parseJsonLines(text) {
@@ -227,20 +291,49 @@ function runCase(name, prompt, sessionExpectations) {
   ok(`real-session ${name}`);
 }
 
-ensureClaudeCli();
-ensureHello2ccEnabled();
+function main() {
+  ensureClaudeCli();
+  const pluginState = ensureHello2ccEnabled();
+  let primaryError = null;
 
-runCase('baseline', 'Reply with exactly OK.', [
-  'Claude Code Guide',
-  'ToolSearch',
-  'General-Purpose',
-  'TeamCreate',
-  'force-for-plugin',
-]);
-runCase('repeat', 'Reply with exactly STILL_OK.', [
-  'Claude Code Guide',
-  'ToolSearch',
-  'General-Purpose',
-  'TeamCreate',
-  'force-for-plugin',
-]);
+  try {
+    runCase('baseline', 'Reply with exactly OK.', [
+      'Claude Code Guide',
+      'ToolSearch',
+      'General-Purpose',
+      'TeamCreate',
+      'force-for-plugin',
+    ]);
+    runCase('repeat', 'Reply with exactly STILL_OK.', [
+      'Claude Code Guide',
+      'ToolSearch',
+      'General-Purpose',
+      'TeamCreate',
+      'force-for-plugin',
+    ]);
+  } catch (error) {
+    primaryError = error;
+  }
+
+  try {
+    pluginState.restore();
+  } catch (restoreError) {
+    if (primaryError) {
+      primaryError.message = `${primaryError.message} (restore also failed: ${restoreError.message})`;
+      throw primaryError;
+    }
+
+    throw restoreError;
+  }
+
+  if (primaryError) {
+    throw primaryError;
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`FAIL ${error.message}`);
+  process.exit(1);
+}

--- a/tests/notify-compat.test.mjs
+++ b/tests/notify-compat.test.mjs
@@ -1,13 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const scriptPath = resolve('scripts/notify.mjs');
+const realRegressionScriptPath = resolve('scripts/claude-real-regression.mjs');
+const repoRoot = resolve('.');
 
-function isolatedEnv() {
+function isolatedEnv(overrides = {}) {
   const root = mkdtempSync(join(tmpdir(), 'hello2cc-notify-test-'));
 
   return {
@@ -16,6 +18,7 @@ function isolatedEnv() {
     USERPROFILE: root,
     CLAUDE_PLUGIN_DATA: join(root, 'plugin-data'),
     CLAUDE_PLUGIN_ROOT: resolve('.'),
+    ...overrides,
   };
 }
 
@@ -29,6 +32,55 @@ function runNotify(args, payload = '', env = isolatedEnv()) {
 
   assert.equal(result.status, 0, result.stderr);
   return result;
+}
+
+function createFakeClaudeHome(root, behavior) {
+  const appData = join(root, 'appdata');
+  const npmDir = join(appData, 'npm');
+  mkdirSync(npmDir, { recursive: true });
+
+  const logPath = join(root, 'claude-log.txt');
+  const stdoutFile = join(root, 'stream.jsonl');
+  if (behavior.streamJsonl) {
+    writeFileSync(stdoutFile, behavior.streamJsonl, 'utf8');
+  }
+
+  const quotedLogPath = logPath.replace(/'/g, "''");
+  const quotedStdoutFile = stdoutFile.replace(/'/g, "''");
+  const quotedStderr = String(behavior.stderrOutput || '').replace(/'/g, "''");
+  const quotedPrintStderr = String(behavior.printStderr || '').replace(/'/g, "''");
+  const exitCode = Number.isInteger(behavior.exitCode) ? behavior.exitCode : 42;
+  const printExitCode = Number.isInteger(behavior.printExitCode) ? behavior.printExitCode : (behavior.streamJsonl ? 0 : exitCode);
+  const enableExitCode = Number.isInteger(behavior.enableExitCode) ? behavior.enableExitCode : 0;
+  const disableExitCode = Number.isInteger(behavior.disableExitCode) ? behavior.disableExitCode : 0;
+  const listLines = String(behavior.listOutput || '')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => `Write-Output '${String(line).replace(/'/g, "''")}'`)
+    .join('\n');
+  const printBody = behavior.streamJsonl ? `Get-Content -Raw '${quotedStdoutFile}' | Write-Output` : '';
+
+  const psScript = `param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Rest)
+$logPath = '${quotedLogPath}'
+if ($Rest) { Add-Content -Path $logPath -Value ($Rest -join ' ') }
+if ($Rest.Count -ge 2 -and (($Rest[0] -eq 'plugin') -or ($Rest[0] -eq 'plugins')) -and $Rest[1] -eq '--help') { exit 0 }
+if ($Rest.Count -ge 2 -and (($Rest[0] -eq 'plugin') -or ($Rest[0] -eq 'plugins')) -and $Rest[1] -eq 'list') {
+${listLines}
+  exit 0
+}
+if ($Rest.Count -ge 2 -and (($Rest[0] -eq 'plugin') -or ($Rest[0] -eq 'plugins')) -and $Rest[1] -eq 'enable') { exit ${enableExitCode} }
+if ($Rest.Count -ge 2 -and (($Rest[0] -eq 'plugin') -or ($Rest[0] -eq 'plugins')) -and $Rest[1] -eq 'disable') { exit ${disableExitCode} }
+if ($Rest.Count -ge 1 -and $Rest[0] -eq '-p') {
+  if (${behavior.printStderr ? '$true' : '$false'}) { [Console]::Error.WriteLine('${quotedPrintStderr}') }
+  ${printBody}
+  exit ${printExitCode}
+}
+if (${behavior.stderrOutput ? '$true' : '$false'}) { [Console]::Error.WriteLine('${quotedStderr}') }
+exit ${exitCode}
+`;
+
+  writeFileSync(join(npmDir, 'claude.ps1'), psScript, 'utf8');
+  return { appData, logPath, stdoutFile };
 }
 
 test('notify inject stays compatible with the new session-start orchestration', () => {
@@ -62,3 +114,89 @@ test('notify codex-notify exits cleanly for stale notification-program reference
   assert.equal(result.stdout, '');
   assert.equal(result.stderr, '');
 });
+
+test('real regression script fails fast when Claude CLI is unavailable', () => {
+  const result = spawnSync(process.execPath, [realRegressionScriptPath], {
+    cwd: repoRoot,
+    env: {
+      ...isolatedEnv(),
+      PATH: '',
+      APPDATA: '',
+    },
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /claude CLI is required for real-session regression/);
+});
+
+test('windows fake claude home can fail -p invocations and exposes logPath', () => {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  const root = mkdtempSync(join(tmpdir(), 'hello2cc-fake-claude-home-'));
+  const fake = createFakeClaudeHome(root, {
+    listOutput: '  ❯ hello2cc@hello2cc-local\n    Version: 0.1.1\n    Scope: user\n    Status: ✔ enabled\n',
+    printStderr: 'ORIGINAL_STDERR',
+    printExitCode: 42,
+    exitCode: 0,
+  });
+
+  const ps1Path = join(fake.appData, 'npm', 'claude.ps1');
+  const ps1Text = readFileSync(ps1Path, 'utf8');
+  assert.ok(fake.logPath.endsWith('claude-log.txt'));
+  assert.match(ps1Text, /\$Rest\[0\] -eq '-p'/);
+  assert.match(ps1Text, /ORIGINAL_STDERR/);
+  assert.match(ps1Text, /exit 42/);
+});
+
+test('real regression script does not hide the original Claude failure', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const root = mkdtempSync(join(tmpdir(), 'hello2cc-fake-claude-'));
+  const fakeClaude = join(root, 'claude');
+  writeFileSync(fakeClaude, '#!/bin/sh\nif [ "$1" = "plugin" ] || [ "$1" = "plugins" ]; then exit 0; fi\necho ORIGINAL_STDERR 1>&2\nexit 42\n', { mode: 0o755 });
+
+  const result = spawnSync(process.execPath, [realRegressionScriptPath], {
+    cwd: repoRoot,
+    env: {
+      ...isolatedEnv(),
+      PATH: `${root}:${process.env.PATH || ''}`,
+      APPDATA: '',
+      HELLO2CC_REAL_MODEL: 'opus',
+    },
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /ORIGINAL_STDERR/);
+});
+
+test('real regression script preserves original error when restore also fails', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const root = mkdtempSync(join(tmpdir(), 'hello2cc-fake-restore-fail-'));
+  const fakeClaude = join(root, 'claude');
+  writeFileSync(fakeClaude, '#!/bin/sh\nif [ "$1" = "plugin" ] || [ "$1" = "plugins" ]; then\n  if [ "$2" = "--help" ]; then exit 0; fi\n  if [ "$2" = "list" ]; then\n    printf "hello2cc@hello2cc-local\\n  Scope: user\\n  Status: ✘ disabled\\n"\n    exit 0\n  fi\n  if [ "$2" = "enable" ]; then exit 0; fi\n  if [ "$2" = "disable" ]; then exit 9; fi\n  exit 0\nfi\necho ORIGINAL_STDERR 1>&2\nexit 42\n', { mode: 0o755 });
+
+  const result = spawnSync(process.execPath, [realRegressionScriptPath], {
+    cwd: repoRoot,
+    env: {
+      ...isolatedEnv(),
+      PATH: `${root}:${process.env.PATH || ''}`,
+      APPDATA: '',
+      HELLO2CC_REAL_MODEL: 'opus',
+    },
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /ORIGINAL_STDERR/);
+  assert.match(result.stderr, /restore also failed/);
+});
+


### PR DESCRIPTION
## Summary
- preserve original Claude regression failures while still restoring plugin state when tests temporarily enable hello2cc
- avoid duplicate Windows Claude invocations and make plugin list parsing less dependent on CLI formatting details
- add targeted regression coverage for missing CLI, Windows fake hook behavior, and restore-error handling

## Test plan
- [x] npm test
- [x] npm run test:real

🤖 Generated with [Claude Code](https://claude.com/claude-code)